### PR TITLE
Ensure footer sticks to bottom of page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,9 +15,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased">
+      <body className="flex min-h-screen flex-col antialiased">
         <NavBar />
-        <main className="mx-auto max-w-4xl p-4">{children}</main>
+        <main className="mx-auto w-full max-w-4xl flex-1 p-4">{children}</main>
         <Footer />
       </body>
     </html>


### PR DESCRIPTION
## Summary
- make page container flex column so footer stays at bottom on all viewports
- allow main content to grow and fill space so footer sits flush on short pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899c22d2d40832cb7309080d3166ebc